### PR TITLE
Removed content length zero restriction

### DIFF
--- a/parse-response.js
+++ b/parse-response.js
@@ -52,8 +52,8 @@ function parseResponse(data, opt) {
 
   const contentLengthText = headers['content-length'];
   if (contentLengthText) {
-    if (!contentLengthText.match(/^[1-9][0-9]*$/)) {
-      throw new Error('Content-Length does not match /^[1-9][0-9]*$/');
+    if (!contentLengthText.match(/^[0-9]*$/)) {
+      throw new Error('Content-Length does not match /^[0-9]*$/');
     }
     const contentLength = parseInt(contentLengthText, 10);
     if (contentLength != rawBodyData.length) {


### PR DESCRIPTION
In http specification: https://tools.ietf.org/html/rfc2616#page-119

Content length is allowed to be zero:
```
   Any Content-Length greater than or equal to zero is a valid value.
   Section 4.4 describes how to determine the length of a message-body
   if a Content-Length is not given.
```

#2